### PR TITLE
Switch to new appstream ostree branch

### DIFF
--- a/appstream-extractor/appstream-extractor.sh
+++ b/appstream-extractor/appstream-extractor.sh
@@ -11,7 +11,7 @@ APPSTREAM_EXTRACTOR_DEST_FOLDER=$APPSTREAM_EXTRACTOR_HOME/export-data
 
 FLATPAK_OSTREE_REPO_PATH=/var/lib/flatpak/repo/
 FLATPAK_REMOTE_NAME=flathub
-FLATPAK_REF_APPSTREAM_X86_64=flathub/appstream/x86_64 
+FLATPAK_REF_APPSTREAM_X86_64=flathub/appstream2/x86_64 
 
 function check-required-programs {
 	command -v flatpak >/dev/null 2>&1 || { echo >&2 "I require flatpak but it's not installed.  Aborting."; exit 1; }


### PR DESCRIPTION
With the latest version of flatpak, we now default to using the new appstream branch called appstream2/$arch that has an uncompressed appstream.xml. Using the old name in the script means we never detected that flatpak pulled a new version.

Note, this means you also have to update flatpak on the backend machine.